### PR TITLE
Use double context manager for tempdirs

### DIFF
--- a/commpare/utils.py
+++ b/commpare/utils.py
@@ -1,0 +1,29 @@
+import contextlib
+import tempfile
+import shutil
+
+# Useful routines to safely build and tear down temporary
+# directories when invoking MM engines
+
+# Taken from
+# https://github.com/rsdefever/foyer/blob/2bb9d60a49e13406330efc207593d0fe85b0adce/foyer/utils/tempdir.py
+
+@contextlib.contextmanager
+def temporary_directory():
+    import shutil
+    import tempfile
+    tmp_dir = tempfile.mkdtemp()
+    try:
+        yield tmp_dir
+    finally:
+        shutil.rmtree(tmp_dir)
+
+@contextlib.contextmanager
+def temporary_cd(dir_path):
+    import os
+    prev_dir = os.getcwd()
+    os.chdir(os.path.abspath(dir_path))
+    try:
+        yield
+    finally:
+        os.chdir(prev_dir)


### PR DESCRIPTION
Use double context manager and also update gromacs utils
```
test_gromacs_conversion.py angle1_vacuum
Processing LJ and QQ
Processing 1-4 interactions, adjusting neighborlist exclusions
No 1,4 pairs found in hoomd snapshot
Processing harmonic bonds
Processing harmonic angles
HOOMD SimulationContext updated from ParmEd Structure
             bond      angle  dihedral     nonbond         all
gromacs  1.310600  21.928799         0    5.050645   29.055742
openmm   1.310602  21.928802         0    5.823008   29.062412
hoomd    1.310587  20.117457         0  115.253015  136.681059
====================
dihedral1_vacuum
Processing LJ and QQ
Processing 1-4 interactions, adjusting neighborlist exclusions
Processing harmonic bonds
Processing harmonic angles
Processing periodic torsions
HOOMD SimulationContext updated from ParmEd Structure
             bond      angle   dihedral    nonbond         all
gromacs  1.310600  20.117447  15.702407   5.050645   42.946796
openmm   1.310602  20.117451   0.000000   5.823008   42.953472
hoomd    1.310587  20.117457  14.692933  95.352620  131.473597
====================
pairs1_vacuum
Processing LJ and QQ
Processing 1-4 interactions, adjusting neighborlist exclusions
Processing harmonic bonds
Processing harmonic angles
Processing RB torsions
HOOMD SimulationContext updated from ParmEd Structure
             bond      angle  dihedral     nonbond         all
gromacs  1.310600  21.928799  0.181392    5.050645   29.237135
openmm   1.310602  21.928802  0.181389  122.732521  146.153320
hoomd    1.310587  20.117457  0.181425  295.114388  316.723857
```